### PR TITLE
add robots.txt, sitemap.xml, canonical, OG/Twitter, JSON-LD

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,63 @@
       name="description"
       content="Personal site of Vigneshraj Sekar Babu (Vignesh), a senior software engineer on the Developer Tools team at GoodRx in Los Angeles. Building tools that make engineers' lives easier."
     />
+    <link rel="canonical" href="https://vigneshrajsb.com/" />
+    <meta name="robots" content="index, follow" />
+    <meta name="author" content="Vigneshraj Sekar Babu" />
+
+    <meta property="og:type" content="profile" />
+    <meta property="og:site_name" content="Vignesh — vigneshrajsb.com" />
+    <meta property="og:title" content="Vignesh, Senior Software Engineer in LA" />
+    <meta
+      property="og:description"
+      content="Senior software engineer on the Developer Tools team at GoodRx. Building tools that make engineers' lives easier."
+    />
+    <meta property="og:url" content="https://vigneshrajsb.com/" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="profile:first_name" content="Vigneshraj" />
+    <meta property="profile:last_name" content="Sekar Babu" />
+
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Vignesh, Senior Software Engineer in LA" />
+    <meta
+      name="twitter:description"
+      content="Senior software engineer on the Developer Tools team at GoodRx. Building tools that make engineers' lives easier."
+    />
+
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Person",
+        "name": "Vigneshraj Sekar Babu",
+        "alternateName": "Vignesh",
+        "url": "https://vigneshrajsb.com/",
+        "jobTitle": "Senior Software Engineer",
+        "worksFor": {
+          "@type": "Organization",
+          "name": "GoodRx",
+          "url": "https://www.goodrx.com"
+        },
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Los Angeles",
+          "addressRegion": "CA",
+          "addressCountry": "US"
+        },
+        "email": "mailto:vignesh.raj47@gmail.com",
+        "sameAs": [
+          "https://github.com/vigneshrajsb",
+          "https://www.linkedin.com/in/vigneshrajsb/",
+          "https://vigneshrajsb.medium.com"
+        ],
+        "knowsAbout": [
+          "Developer Tools",
+          "Test Automation",
+          "Infrastructure",
+          "Software Engineering"
+        ]
+      }
+    </script>
+
     <link rel="icon" href="/favicon.ico" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://vigneshrajsb.com/sitemap.xml
+
+# Agents: there's a markdown summary at /llms.txt

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://vigneshrajsb.com/</loc>
+    <lastmod>2026-04-26</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- Adds `/robots.txt` (allow-all + sitemap pointer + agent breadcrumb to `/llms.txt`).
- Adds `/sitemap.xml` listing the canonical home URL with `lastmod`.
- `index.html` head additions:
  - `<link rel=\"canonical\">` so Vercel preview URLs don't compete with the canonical domain in search results.
  - Explicit `<meta name=\"robots\" content=\"index, follow\">`.
  - Open Graph profile tags + Twitter summary card for clean link previews on Slack, iMessage, X, etc.
  - JSON-LD `Person` schema (name, role, employer, LA address, `sameAs` to GitHub/LinkedIn/Medium) for Google's knowledge graph eligibility.

## Test plan
- [ ] Vercel preview serves `/robots.txt` and `/sitemap.xml` as plain text / xml
- [ ] `<link rel=\"canonical\">` resolves to the production URL on every page
- [ ] OG tags render in [opengraph.xyz](https://www.opengraph.xyz/) preview
- [ ] JSON-LD validates in [Google Rich Results Test](https://search.google.com/test/rich-results)
- [ ] After merge: re-submit sitemap in Google Search Console → Sitemaps